### PR TITLE
Fixes column math to replicate original

### DIFF
--- a/less/skeleton.less
+++ b/less/skeleton.less
@@ -43,10 +43,11 @@
 // Grid Variables
 @container-width: 960px;
   @total-columns: 12; 
-   @column-width: 100 / @total-columns; // calculates individual column width based off of # of columns
   @column-margin: 3.666666666666%; // space between columns
+   @column-space: 100 - (@column-margin * (@total-columns - 1)); // total space a full row of columns can occupy
+   @column-width: @column-space / @total-columns; // calculates individual column width based off of # of columns
  @column-padding: 4px 8px; // space inside columns
-      @row-space:2rem; // Margin-bottom for .row
+      @row-space: 2rem; // Margin-bottom for .row
 
 
 // Breakpoints
@@ -94,42 +95,42 @@
   }
   
   .container .one.column,
-  .container .one.columns          { width: @column-width * 1 - (@column-margin);  }
-  .container .two.columns          { width: @column-width * 2 - (@column-margin);  }
-  .container .three.columns        { width: @column-width * 3 - (@column-margin);  }
-  .container .four.columns         { width: @column-width * 4 - (@column-margin);  }
-  .container .five.columns         { width: @column-width * 5 - (@column-margin);  }
-  .container .six.columns          { width: @column-width * 6 - (@column-margin);  }
-  .container .seven.columns        { width: @column-width * 7 - (@column-margin);  }
-  .container .eight.columns        { width: @column-width * 8 - (@column-margin);  }
-  .container .nine.columns         { width: @column-width * 9 - (@column-margin);  }
-  .container .ten.columns          { width: @column-width * 10 - (@column-margin); }
-  .container .eleven.columns       { width: @column-width * 11 - (@column-margin); }
+  .container .one.columns          { width: @column-width * 1;  }
+  .container .two.columns          { width: @column-width * 2 + (@column-margin * 1);  }
+  .container .three.columns        { width: @column-width * 3 + (@column-margin * 2);  }
+  .container .four.columns         { width: @column-width * 4 + (@column-margin * 3);  }
+  .container .five.columns         { width: @column-width * 5 + (@column-margin * 4);  }
+  .container .six.columns          { width: @column-width * 6 + (@column-margin * 5);  }
+  .container .seven.columns        { width: @column-width * 7 + (@column-margin * 6);  }
+  .container .eight.columns        { width: @column-width * 8 + (@column-margin * 7);  }
+  .container .nine.columns         { width: @column-width * 9 + (@column-margin * 8);  }
+  .container .ten.columns          { width: @column-width * 10 + (@column-margin * 9); }
+  .container .eleven.columns       { width: @column-width * 11 + (@column-margin * 10); }
   .container .twelve.columns       { width: 100%; margin-left: 0; }
 
-  .container .one-third.column     { width: @column-width * 4 - (@column-margin);  }
-  .container .two-thirds.column    { width: @column-width * 8 - (@column-margin);  }
+  .container .one-third.column     { width: @column-width * 4 + (@column-margin * 3);  }
+  .container .two-thirds.column    { width: @column-width * 8 + (@column-margin * 7);  }
 
-  .container .one-half.column      { width: @column-width * 6 - (@column-margin);  }
+  .container .one-half.column      { width: @column-width * 6 + (@column-margin * 5);  }
 
   /* Offsets */
   .container .offset-by-one.column,
-  .container .offset-by-one.columns       { margin-left: @column-width * 1 - (@column-margin);  }
-  .container .offset-by-two.column        { margin-left: @column-width * 2 - (@column-margin);  }
-  .container .offset-by-three.column      { margin-left: @column-width * 3 - (@column-margin);  }            
-  .container .offset-by-four.column       { margin-left: @column-width * 4 - (@column-margin);  }
-  .container .offset-by-five.column       { margin-left: @column-width * 5 - (@column-margin);  }
-  .container .offset-by-six.column        { margin-left: @column-width * 6 - (@column-margin);  }            
-  .container .offset-by-seven.column      { margin-left: @column-width * 7 - (@column-margin);  }
-  .container .offset-by-eight.column      { margin-left: @column-width * 8 - (@column-margin);  }
-  .container .offset-by-nine.column       { margin-left: @column-width * 9 - (@column-margin);  }          
-  .container .offset-by-ten.column        { margin-left: @column-width * 10 - (@column-margin); }
-  .container .offset-by-eleven.column     { margin-left: @column-width * 11 - (@column-margin); }
+  .container .offset-by-one.columns       { margin-left: @column-width * 1 + (@column-margin);  }
+  .container .offset-by-two.column        { margin-left: @column-width * 2 + (@column-margin * 2);  }
+  .container .offset-by-three.column      { margin-left: @column-width * 3 + (@column-margin * 3);  }
+  .container .offset-by-four.column       { margin-left: @column-width * 4 + (@column-margin * 4);  }
+  .container .offset-by-five.column       { margin-left: @column-width * 5 + (@column-margin * 5);  }
+  .container .offset-by-six.column        { margin-left: @column-width * 6 + (@column-margin * 6);  }
+  .container .offset-by-seven.column      { margin-left: @column-width * 7 + (@column-margin * 7);  }
+  .container .offset-by-eight.column      { margin-left: @column-width * 8 + (@column-margin * 8);  }
+  .container .offset-by-nine.column       { margin-left: @column-width * 9 + (@column-margin * 9);  }
+  .container .offset-by-ten.column        { margin-left: @column-width * 10 + (@column-margin * 10); }
+  .container .offset-by-eleven.column     { margin-left: @column-width * 11 + (@column-margin * 11); }
 
-  .container .offset-by-one-third.column  { margin-left: @column-width * 4 - (@column-margin); }
-  .container .offset-by-two-thirds.column { margin-left: @column-width * 8 - (@column-margin); }
+  .container .offset-by-one-third.column  { margin-left: @column-width * 4 + (@column-margin * 3); }
+  .container .offset-by-two-thirds.column { margin-left: @column-width * 8 + (@column-margin * 7); }
 
-  .container .offset-by-one-half.column   { margin-left: @column-width * 1 - (@column-margin); }
+  .container .offset-by-one-half.column   { margin-left: @column-width * 6 + (@column-margin * 5); }
 
 }
 

--- a/less/skeleton.less
+++ b/less/skeleton.less
@@ -127,10 +127,10 @@
   .container .offset-by-ten.column        { margin-left: @column-width * 10 + (@column-margin * 10); }
   .container .offset-by-eleven.column     { margin-left: @column-width * 11 + (@column-margin * 11); }
 
-  .container .offset-by-one-third.column  { margin-left: @column-width * 4 + (@column-margin * 3); }
-  .container .offset-by-two-thirds.column { margin-left: @column-width * 8 + (@column-margin * 7); }
+  .container .offset-by-one-third.column  { margin-left: @column-width * 4 + (@column-margin * 4); }
+  .container .offset-by-two-thirds.column { margin-left: @column-width * 8 + (@column-margin * 8); }
 
-  .container .offset-by-one-half.column   { margin-left: @column-width * 6 + (@column-margin * 5); }
+  .container .offset-by-one-half.column   { margin-left: @column-width * 6 + (@column-margin * 6); }
 
 }
 


### PR DESCRIPTION
Currently, the calculation is:

```
specific-column-width = base-column-width * column-span - column-margin
```

Unless you use twelve columns, any combination of columns will never equal 100%, resulting in something like this:

![Alignment issue](http://i.imgur.com/weIjNre.png)

The current calculation isn't taking into consideration the **total** left-margin provided by each individual column.

```
@marginWidth: 2%;
@columnCount: 12;

.columnCalc(@columns, @i: 1) when (@i <= @columns) {
  .@{i} {
    &.columns {
      width: (((100 - @marginWidth * (@columns - 1)) / @columns) * @i) + ((@i - 1) * @marginWidth);
    }
  }
  .columnCalc(@columns, @i + 1);
}

.columnCalc(@columnCount);
```

First, `100 - @marginWidth * (@columns - 1)` calculates the total amount of space a full row (12 in this example) of `<div class="one column">` can occupy.

This is then divided by the total number of columns possible, giving you a single column's width.

The single column's width is then multiplied by the iterator. The iterator, `@i`, represents how many columns to span by (ie. the .seven in .seven.columns). This gives you the width of the column **without** taking into consideration each margin-left.

`+ ((@i - 1) * @marginWidth` will then add the missing margin width to the total width of the column.

A downside to the above is that it will generate `.x.columns` classes and not something like `.two.columns`, so I in lieu of the loop I simply added a single variable and modified existing ones.
