### PR TITLE
Fixes to offset-by-*

### DIFF
--- a/less/skeleton.less
+++ b/less/skeleton.less
@@ -68,7 +68,10 @@
 }
 
 .grid-offset-length(@n) {
-  margin-left: @column-width * @n - (@column-margin*(@total-columns - @n)/@total-columns) + @column-margin;
+  margin-left: (@column-width * @n) - (@column-margin*(@total-columns - @n)/@total-columns) + @column-margin;
+  &:not(:first-child) {
+    margin-left: (@column-width * @n) - (@column-margin*(@total-columns - @n)/@total-columns) + (@column-margin * 2);
+  }
 }
 
 /* Grid


### PR DESCRIPTION
Currently offset-by-* following another column doesn't fill the whole row. There's related pull request on main Skeleton project that fixes this https://github.com/dhg/Skeleton/pull/305